### PR TITLE
Format code

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,5 @@
 tabWidth: 4
-printWidth: 100
+printWidth: 120
 trailingComma: 'all'
 singleQuote: true
 bracketSpacing: false

--- a/CRM/MagnetXmlImport/Form/MagnetXMLImport.php
+++ b/CRM/MagnetXmlImport/Form/MagnetXMLImport.php
@@ -35,15 +35,14 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImport extends CRM_Core_Form
 
     /**
      * Build form
-     *
      * The list of the contact parameters are based on this solution:
      * https://github.com/civicrm/civicrm-core/blob/master/CRM/UF/Form/Field.php#L237-L247
      */
     public function buildQuickForm()
     {
         $this->add('text', 'source', ts('Source'), [], true);
-        $this->add('select', 'financialTypeId', ts('Financial Type'), [''=>ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'), true);
-        $this->add('select', 'paymentInstrumentId', ts('Payment method'), [''=>ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'search'), true);
+        $this->add('select', 'financialTypeId', ts('Financial Type'), ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'), true);
+        $this->add('select', 'paymentInstrumentId', ts('Payment method'), ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'search'), true);
         $fields = CRM_Core_BAO_UFField::getAvailableFields();
         $contactParamNames = ['Contact', 'Individual'];
         $paramOptions = [];
@@ -56,13 +55,13 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImport extends CRM_Core_Form
                 if ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key1)) {
                     $customGroupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomField', $customFieldId, 'custom_group_id');
                     $customGroupName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupId, 'title');
-                    $paramOptions[$key1] = $value1['title'] . ' :: ' . $customGroupName;
+                    $paramOptions[$key1] = $value1['title'].' :: '.$customGroupName;
                 } else {
                     $paramOptions[$key1] = $value1['title'];
                 }
             }
         }
-        $this->add('select', 'bankAccountNumberParameter', ts('Bank Account'), [''=>ts('- select -')] + $paramOptions, true);
+        $this->add('select', 'bankAccountNumberParameter', ts('Bank Account'), ['' => ts('- select -')] + $paramOptions, true);
         $this->add('checkbox', 'onlyIncome', ts('Only income'), [], false);
         $this->add('file', 'importSource', ts('Magnet XML file'), [], true);
         $formParameterNames = ['source', 'financialTypeId', 'paymentInstrumentId', 'bankAccountNumberParameter', 'onlyIncome', 'importSource'];
@@ -84,6 +83,7 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImport extends CRM_Core_Form
     {
         $this->addFormRule(['CRM_MagnetXmlImport_Form_MagnetXMLImport', 'fileExtension']);
     }
+
     /**
      * Accept only xml files.
      */
@@ -94,6 +94,7 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImport extends CRM_Core_Form
         if (array_search($files['importSource']['type'], $validTypes) === false) {
             $errors['importSource'] = E::ts('Only XML files allowed.');
         }
+
         return empty($errors) ? true : $errors;
     }
 

--- a/CRM/MagnetXmlImport/Service.php
+++ b/CRM/MagnetXmlImport/Service.php
@@ -5,7 +5,9 @@ use CRM_MagnetXmlImport_ExtensionUtil as E;
 class CRM_MagnetXmlImport_Service
 {
     private $filePath;
+
     private $config;
+
     private $stats;
 
     public function __construct(array $config, string $path)
@@ -97,6 +99,7 @@ class CRM_MagnetXmlImport_Service
         }
         // Still not found. Create a brand new contact based on $contactData
         $contact = civicrm_api3('Contact', 'create', $contactData);
+
         return $contact['id'];
     }
 
@@ -136,6 +139,7 @@ class CRM_MagnetXmlImport_Service
         } catch (Exception $e) {
             $this->raiseError('Failed to detect duplication for the following transaction: '.$trxnId.' Details: '.$e->getMessage());
         }
+
         return false;
     }
 
@@ -156,10 +160,12 @@ class CRM_MagnetXmlImport_Service
                 $contribution = $contribution->addValue($key, $value);
             }
             $contribution->execute();
+
             return true;
         } catch (Exception $e) {
             $this->raiseError('Failed to create CRM contribution for the following transaction: '.$params['trxn_id'].' Details: '.$e->getMessage());
         }
+
         return false;
     }
 }

--- a/CRM/MagnetXmlImport/Transformer.php
+++ b/CRM/MagnetXmlImport/Transformer.php
@@ -5,9 +5,11 @@ use CRM_MagnetXmlImport_ExtensionUtil as E;
 /*
  * This class contains the data transformation rules.
  */
+
 class CRM_MagnetXmlImport_Transformer
 {
     const CRM_COMPLETED_STATUS_ID = 1;
+
     /**
      * Transform Magnet transaction data to civicrm contact data
      *
@@ -20,8 +22,8 @@ class CRM_MagnetXmlImport_Transformer
     {
         return [
             'contact_type' => 'Individual',
-            'display_name' => (string) $transaction->Ellenpartner,
-            $bankAccountNumberContactParamName => (string) $transaction->Ellenszamla,
+            'display_name' => (string)$transaction->Ellenpartner,
+            $bankAccountNumberContactParamName => (string)$transaction->Ellenszamla,
         ];
     }
 
@@ -36,10 +38,10 @@ class CRM_MagnetXmlImport_Transformer
     public static function magnetTransactionToContribution(SimpleXMLElement $transaction, array $config): array
     {
         return [
-            'trxn_id' => (string) $transaction->Tranzakcioszam,
-            'total_amount' => (float) $transaction->Osszeg,
-            'currency' => (string) $transaction->Osszeg->attributes()['Devizanem'],
-            'receive_date' => str_replace('.', '', (string) $transaction->Esedekessegnap), // we need 20150131
+            'trxn_id' => (string)$transaction->Tranzakcioszam,
+            'total_amount' => (float)$transaction->Osszeg,
+            'currency' => (string)$transaction->Osszeg->attributes()['Devizanem'],
+            'receive_date' => str_replace('.', '', (string)$transaction->Esedekessegnap), // we need 20150131
             'source' => $config['source'],
             'financial_type_id' => $config['financialTypeId'],
             'payment_instrument_id' => $config['paymentInstrumentId'],

--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ install it with the command-line tool [cv](https://github.com/civicrm/cv).
 
 ```bash
 git clone https://github.com/reflexive-communications/magnet-xml-import.git
-cv en magnet_xml_import
+cv en magnet-xml-import
 ```

--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/magnet-xml-import/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2022-11-06</releaseDate>
-    <version>1.0.4</version>
+    <releaseDate>2023-03-08</releaseDate>
+    <version>1.0.5</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/magnet_xml_import.civix.php
+++ b/magnet_xml_import.civix.php
@@ -9,18 +9,20 @@
 class CRM_MagnetXmlImport_ExtensionUtil
 {
     const SHORT_NAME = 'magnet_xml_import';
+
     const LONG_NAME = 'magnet-xml-import';
+
     const CLASS_PREFIX = 'CRM_MagnetXmlImport';
 
     /**
      * Translate a string using the extension's domain.
-     *
      * If the extension doesn't have a specific translation
      * for the string, fallback to the default translations.
      *
      * @param string $text
      *   Canonical message text (generally en_US).
      * @param array $params
+     *
      * @return string
      *   Translated text.
      * @see ts
@@ -30,6 +32,7 @@ class CRM_MagnetXmlImport_ExtensionUtil
         if (!array_key_exists('domain', $params)) {
             $params['domain'] = [self::LONG_NAME, null];
         }
+
         return ts($text, $params);
     }
 
@@ -39,6 +42,7 @@ class CRM_MagnetXmlImport_ExtensionUtil
      * @param string|NULL $file
      *   Ex: NULL.
      *   Ex: 'css/foo.css'.
+     *
      * @return string
      *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
      *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
@@ -48,6 +52,7 @@ class CRM_MagnetXmlImport_ExtensionUtil
         if ($file === null) {
             return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
         }
+
         return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
     }
 
@@ -57,6 +62,7 @@ class CRM_MagnetXmlImport_ExtensionUtil
      * @param string|NULL $file
      *   Ex: NULL.
      *   Ex: 'css/foo.css'.
+     *
      * @return string
      *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
      *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
@@ -64,7 +70,7 @@ class CRM_MagnetXmlImport_ExtensionUtil
     public static function path($file = null)
     {
         // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
-        return __DIR__ . ($file === null ? '' : (DIRECTORY_SEPARATOR . $file));
+        return __DIR__.($file === null ? '' : (DIRECTORY_SEPARATOR.$file));
     }
 
     /**
@@ -72,12 +78,13 @@ class CRM_MagnetXmlImport_ExtensionUtil
      *
      * @param string $suffix
      *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+     *
      * @return string
      *   Ex: 'CRM_Foo_Page_HelloWorld'.
      */
     public static function findClass($suffix)
     {
-        return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+        return self::CLASS_PREFIX.'_'.str_replace('\\', '_', $suffix);
     }
 }
 
@@ -98,8 +105,8 @@ function _magnet_xml_import_civix_civicrm_config(&$config = null)
 
     $template =& CRM_Core_Smarty::singleton();
 
-    $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-    $extDir = $extRoot . 'templates';
+    $extRoot = dirname(__FILE__).DIRECTORY_SEPARATOR;
+    $extDir = $extRoot.'templates';
 
     if (is_array($template->template_dir)) {
         array_unshift($template->template_dir, $extDir);
@@ -107,7 +114,7 @@ function _magnet_xml_import_civix_civicrm_config(&$config = null)
         $template->template_dir = [$extDir, $template->template_dir];
     }
 
-    $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+    $include_path = $extRoot.PATH_SEPARATOR.get_include_path();
     set_include_path($include_path);
 }
 
@@ -120,7 +127,7 @@ function _magnet_xml_import_civix_civicrm_config(&$config = null)
  */
 function _magnet_xml_import_civix_civicrm_xmlMenu(&$files)
 {
-    foreach (_magnet_xml_import_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+    foreach (_magnet_xml_import_civix_glob(__DIR__.'/xml/Menu/*.xml') as $file) {
         $files[] = $file;
     }
 }
@@ -206,7 +213,6 @@ function _magnet_xml_import_civix_civicrm_disable()
  * @return mixed
  *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *   for 'enqueue', returns void
- *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _magnet_xml_import_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
@@ -221,7 +227,7 @@ function _magnet_xml_import_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = 
  */
 function _magnet_xml_import_civix_upgrader()
 {
-    if (!file_exists(__DIR__ . '/CRM/MagnetXmlImport/Upgrader.php')) {
+    if (!file_exists(__DIR__.'/CRM/MagnetXmlImport/Upgrader.php')) {
         return null;
     } else {
         return CRM_MagnetXmlImport_Upgrader_Base::instance();
@@ -230,7 +236,6 @@ function _magnet_xml_import_civix_upgrader()
 
 /**
  * Search directory tree for files which match a glob pattern.
- *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
@@ -256,7 +261,7 @@ function _magnet_xml_import_civix_find_files($dir, $pattern)
         }
         if ($dh = opendir($subdir)) {
             while (false !== ($entry = readdir($dh))) {
-                $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+                $path = $subdir.DIRECTORY_SEPARATOR.$entry;
                 if ($entry[0] == '.') {
                 } elseif (is_dir($path)) {
                     $todos[] = $path;
@@ -265,12 +270,12 @@ function _magnet_xml_import_civix_find_files($dir, $pattern)
             closedir($dh);
         }
     }
+
     return $result;
 }
 
 /**
  * (Delegated) Implements hook_civicrm_managed().
- *
  * Find any *.mgd.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
@@ -295,49 +300,45 @@ function _magnet_xml_import_civix_civicrm_managed(&$entities)
 
 /**
  * (Delegated) Implements hook_civicrm_caseTypes().
- *
  * Find any and return any files matching "xml/case/*.xml"
- *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _magnet_xml_import_civix_civicrm_caseTypes(&$caseTypes)
 {
-    if (!is_dir(__DIR__ . '/xml/case')) {
+    if (!is_dir(__DIR__.'/xml/case')) {
         return;
     }
 
-    foreach (_magnet_xml_import_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    foreach (_magnet_xml_import_civix_glob(__DIR__.'/xml/case/*.xml') as $file) {
         $name = preg_replace('/\.xml$/', '', basename($file));
         if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
             $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
             throw new CRM_Core_Exception($errorMessage);
         }
         $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
+            'module' => E::LONG_NAME,
+            'name' => $name,
+            'file' => $file,
+        ];
     }
 }
 
 /**
  * (Delegated) Implements hook_civicrm_angularModules().
- *
  * Find any and return any files matching "ang/*.ang.php"
- *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _magnet_xml_import_civix_civicrm_angularModules(&$angularModules)
 {
-    if (!is_dir(__DIR__ . '/ang')) {
+    if (!is_dir(__DIR__.'/ang')) {
         return;
     }
 
-    $files = _magnet_xml_import_civix_glob(__DIR__ . '/ang/*.ang.php');
+    $files = _magnet_xml_import_civix_glob(__DIR__.'/ang/*.ang.php');
     foreach ($files as $file) {
         $name = preg_replace(':\.ang\.php$:', '', basename($file));
         $module = include $file;
@@ -350,12 +351,11 @@ function _magnet_xml_import_civix_civicrm_angularModules(&$angularModules)
 
 /**
  * (Delegated) Implements hook_civicrm_themes().
- *
  * Find any and return any files matching "*.theme.php"
  */
 function _magnet_xml_import_civix_civicrm_themes(&$themes)
 {
-    $files = _magnet_xml_import_civix_glob(__DIR__ . '/*.theme.php');
+    $files = _magnet_xml_import_civix_glob(__DIR__.'/*.theme.php');
     foreach ($files as $file) {
         $themeMeta = include $file;
         if (empty($themeMeta['name'])) {
@@ -370,13 +370,13 @@ function _magnet_xml_import_civix_civicrm_themes(&$themes)
 
 /**
  * Glob wrapper which is guaranteed to return an array.
- *
  * The documentation for glob() says, "On some systems it is impossible to
  * distinguish between empty match and an error." Anecdotally, the return
  * result for an empty match is sometimes array() and sometimes FALSE.
  * This wrapper provides consistency.
  *
  * @link http://php.net/glob
+ *
  * @param string $pattern
  *
  * @return array
@@ -384,6 +384,7 @@ function _magnet_xml_import_civix_civicrm_themes(&$themes)
 function _magnet_xml_import_civix_glob($pattern)
 {
     $result = glob($pattern);
+
     return is_array($result) ? $result : [];
 }
 
@@ -403,11 +404,12 @@ function _magnet_xml_import_civix_insert_navigation_menu(&$menu, $path, $item)
     // If we are done going down the path, insert menu
     if (empty($path)) {
         $menu[] = [
-      'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
-      ], $item),
-    ];
+            'attributes' => array_merge([
+                'label' => CRM_Utils_Array::value('name', $item),
+                'active' => 1,
+            ], $item),
+        ];
+
         return true;
     } else {
         // Find an recurse into the next level down
@@ -422,6 +424,7 @@ function _magnet_xml_import_civix_insert_navigation_menu(&$menu, $path, $item)
                 $found = _magnet_xml_import_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
             }
         }
+
         return $found;
     }
 }
@@ -479,7 +482,7 @@ function _magnet_xml_import_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $p
  */
 function _magnet_xml_import_civix_civicrm_alterSettingsFolders(&$metaDataFolders = null)
 {
-    $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+    $settingsDir = __DIR__.DIRECTORY_SEPARATOR.'settings';
     if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
         $metaDataFolders[] = $settingsDir;
     }
@@ -487,7 +490,6 @@ function _magnet_xml_import_civix_civicrm_alterSettingsFolders(&$metaDataFolders
 
 /**
  * (Delegated) Implements hook_civicrm_entityTypes().
- *
  * Find any *.entityType.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes

--- a/magnet_xml_import.php
+++ b/magnet_xml_import.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'magnet_xml_import.civix.php';
+
 // phpcs:disable
 use CRM_MagnetXmlImport_ExtensionUtil as E;
 
@@ -88,7 +89,6 @@ function magnet_xml_import_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
 
 /**
  * Implements hook_civicrm_managed().
- *
  * Generate a list of entities to create/deactivate/delete when this module
  * is installed, disabled, uninstalled.
  *
@@ -101,9 +101,7 @@ function magnet_xml_import_civicrm_managed(&$entities)
 
 /**
  * Implements hook_civicrm_caseTypes().
- *
  * Generate a list of case-types.
- *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
@@ -115,9 +113,7 @@ function magnet_xml_import_civicrm_caseTypes(&$caseTypes)
 
 /**
  * Implements hook_civicrm_angularModules().
- *
  * Generate a list of Angular modules.
- *
  * Note: This hook only runs in CiviCRM 4.5+. It may
  * use features only available in v4.6+.
  *
@@ -140,7 +136,6 @@ function magnet_xml_import_civicrm_alterSettingsFolders(&$metaDataFolders = null
 
 /**
  * Implements hook_civicrm_entityTypes().
- *
  * Declare entity types provided by this module.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes

--- a/tests/phpunit/CRM/MagnetXmlImport/Form/MagnetXMLImportTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/Form/MagnetXMLImportTest.php
@@ -15,8 +15,8 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImportTest extends \PHPUnit\Framework\Te
     public function setUpHeadless()
     {
         return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->apply();
+            ->installMe(__DIR__)
+            ->apply();
     }
 
     public function setUp(): void
@@ -103,6 +103,7 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImportTest extends \PHPUnit\Framework\Te
         $result = CRM_MagnetXmlImport_Form_MagnetXMLImport::fileExtension([], $fileData);
         self::assertTrue($result);
     }
+
     public function testFileExtensionNotValidFile()
     {
         $fileData = [

--- a/tests/phpunit/CRM/MagnetXmlImport/ServiceTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/ServiceTest.php
@@ -15,8 +15,8 @@ class CRM_MagnetXmlImport_ServiceTest extends \PHPUnit\Framework\TestCase implem
     public function setUpHeadless()
     {
         return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->apply();
+            ->installMe(__DIR__)
+            ->apply();
     }
 
     public function setUp(): void

--- a/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
@@ -59,7 +59,7 @@ class CRM_MagnetXmlImport_TransformerTest extends \PHPUnit\Framework\TestCase
         $transformed = CRM_MagnetXmlImport_Transformer::magnetTransactionToContribution($xml, $config);
         $expected = [
             'trxn_id' => $trxnId,
-            'total_amount' => (float) $amount,
+            'total_amount' => (float)$amount,
             'currency' => $currency,
             'receive_date' => '20160115',
             'source' => $config['source'],

--- a/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
@@ -29,7 +29,8 @@ class CRM_MagnetXmlImport_TransformerTest extends \PHPUnit\Framework\TestCase
     {
         $contactDisplayName = 'Teszt Contact01';
         $bankAccountNumber = 'HU20 1111 2222 3333 4445 0000 0000';
-        $xmlString = '<Tranzakcio><Tranzakcioszam>trxn003</Tranzakcioszam><Osszeg Devizanem="HUF">1000.00</Osszeg><Esedekessegnap>2016.01.15.</Esedekessegnap><Ellenpartner>'.$contactDisplayName.'</Ellenpartner><Ellenszamla>'.$bankAccountNumber.'</Ellenszamla></Tranzakcio>';
+        $xmlString = '<Tranzakcio><Tranzakcioszam>trxn003</Tranzakcioszam><Osszeg Devizanem="HUF">1000.00</Osszeg><Esedekessegnap>2016.01.15.</Esedekessegnap><Ellenpartner>'.$contactDisplayName
+            .'</Ellenpartner><Ellenszamla>'.$bankAccountNumber.'</Ellenszamla></Tranzakcio>';
         $bankAccountName = 'custom_1';
         $xml = simplexml_load_string($xmlString);
         $transformed = CRM_MagnetXmlImport_Transformer::magnetTransactionToContact($xml, $bankAccountName);
@@ -54,7 +55,8 @@ class CRM_MagnetXmlImport_TransformerTest extends \PHPUnit\Framework\TestCase
         $trxnId = 'trxn003';
         $amount = '1000.00';
         $currency = 'HUF';
-        $xmlString = '<Tranzakcio><Tranzakcioszam>'.$trxnId.'</Tranzakcioszam><Osszeg Devizanem="'.$currency.'">'.$amount.'</Osszeg><Esedekessegnap>2016.01.15.</Esedekessegnap><Ellenpartner>Teszt Contact01</Ellenpartner><Ellenszamla>HU20 1111 2222 3333 4445 0000 0000</Ellenszamla></Tranzakcio>';
+        $xmlString = '<Tranzakcio><Tranzakcioszam>'.$trxnId.'</Tranzakcioszam><Osszeg Devizanem="'.$currency.'">'.$amount
+            .'</Osszeg><Esedekessegnap>2016.01.15.</Esedekessegnap><Ellenpartner>Teszt Contact01</Ellenpartner><Ellenszamla>HU20 1111 2222 3333 4445 0000 0000</Ellenszamla></Tranzakcio>';
         $xml = simplexml_load_string($xmlString);
         $transformed = CRM_MagnetXmlImport_Transformer::magnetTransactionToContribution($xml, $config);
         $expected = [

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -20,6 +20,7 @@ $loader->register();
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
+ *
  * @return string
  *   Response output (if the command executed normally).
  * @throws \RuntimeException
@@ -27,8 +28,8 @@ $loader->register();
  */
 function cv($cmd, $decode = 'json')
 {
-    $cmd = 'cv ' . $cmd;
-    $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+    $cmd = 'cv '.$cmd;
+    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
     putenv("CV_OUTPUT=json");
 
@@ -53,6 +54,7 @@ function cv($cmd, $decode = 'json')
             if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
                 throw new \RuntimeException("Command failed ($cmd):\n$result");
             }
+
             return $result;
 
         case 'json':


### PR DESCRIPTION
- Reformat PHP to PSR-12
- Reformat JS
- readme: use hyphens for `cv en some-extension`
- remove `,` after last element of inline arrays
