### PR TITLE
Standardize tests

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/magnet-xml-import/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-09</releaseDate>
-    <version>1.1.0</version>
+    <releaseDate>2023-03-16</releaseDate>
+    <version>1.2.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.27</ver>

--- a/tests/phpunit/CRM/MagnetXmlImport/Form/MagnetXMLImportTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/Form/MagnetXMLImportTest.php
@@ -1,34 +1,12 @@
 <?php
 
-use CRM_MagnetXmlImport_ExtensionUtil as E;
-use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
-use Civi\Test\TransactionalInterface;
+use Civi\MagnetXmlImport\HeadlessTestCase;
 
 /**
- * Testcases for the Admin form functionalities.
- *
  * @group headless
  */
-class CRM_MagnetXmlImport_Form_MagnetXMLImportTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class CRM_MagnetXmlImport_Form_MagnetXMLImportTest extends HeadlessTestCase
 {
-    public function setUpHeadless()
-    {
-        return \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
-    }
-
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     /**
      * PreProcess test case pre process does nothing.
      */

--- a/tests/phpunit/CRM/MagnetXmlImport/Form/MagnetXMLImportTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/Form/MagnetXMLImportTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
 use Civi\MagnetXmlImport\HeadlessTestCase;
 
 /**
@@ -40,13 +42,13 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImportTest extends HeadlessTestCase
      */
     public function testBuildQuickForm()
     {
-        $customGroup = \Civi\Api4\CustomGroup::create(false)
+        $customGroup = CustomGroup::create(false)
             ->addValue('title', 'TestCustomGroup')
             ->addValue('extends', 'Contact')
             ->addValue('is_active', true)
             ->execute()
             ->first();
-        \Civi\Api4\CustomField::create()
+        CustomField::create()
             ->addValue('custom_group_id', $customGroup['id'])
             ->addValue('label', 'bank account number')
             ->addValue('data_type', 'String')
@@ -98,13 +100,13 @@ class CRM_MagnetXmlImport_Form_MagnetXMLImportTest extends HeadlessTestCase
      */
     public function testPostProcess()
     {
-        $customGroup = \Civi\Api4\CustomGroup::create(false)
+        $customGroup = CustomGroup::create(false)
             ->addValue('title', 'TestCustomGroupPostProcess')
             ->addValue('extends', 'Contact')
             ->addValue('is_active', true)
             ->execute()
             ->first();
-        \Civi\Api4\CustomField::create()
+        CustomField::create()
             ->addValue('custom_group_id', $customGroup['id'])
             ->addValue('label', 'bank account number')
             ->addValue('data_type', 'String')

--- a/tests/phpunit/CRM/MagnetXmlImport/ServiceTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/ServiceTest.php
@@ -1,34 +1,12 @@
 <?php
 
-use CRM_MagnetXmlImport_ExtensionUtil as E;
-use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
-use Civi\Test\TransactionalInterface;
+use Civi\MagnetXmlImport\HeadlessTestCase;
 
 /**
- * FIXME - Add test description.
- *
  * @group headless
  */
-class CRM_MagnetXmlImport_ServiceTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class CRM_MagnetXmlImport_ServiceTest extends HeadlessTestCase
 {
-    public function setUpHeadless()
-    {
-        return \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
-    }
-
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     /**
      * Process test case.
      * Create the custom group and field,

--- a/tests/phpunit/CRM/MagnetXmlImport/ServiceTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/ServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\CustomField;
+use Civi\Api4\CustomGroup;
 use Civi\MagnetXmlImport\HeadlessTestCase;
 
 /**
@@ -13,13 +15,13 @@ class CRM_MagnetXmlImport_ServiceTest extends HeadlessTestCase
      */
     public function testProcess()
     {
-        $customGroup = \Civi\Api4\CustomGroup::create(false)
+        $customGroup = CustomGroup::create(false)
             ->addValue('title', 'TestCustomGroupForServiceTests')
             ->addValue('extends', 'Contact')
             ->addValue('is_active', true)
             ->execute()
             ->first();
-        \Civi\Api4\CustomField::create()
+        CustomField::create()
             ->addValue('custom_group_id', $customGroup['id'])
             ->addValue('label', 'bank account number')
             ->addValue('data_type', 'String')

--- a/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
@@ -1,27 +1,12 @@
 <?php
 
+use Civi\MagnetXmlImport\HeadlessTestCase;
+
 /**
  * This is a generic test class for the extension (implemented with PHPUnit).
  */
-class CRM_MagnetXmlImport_TransformerTest extends \PHPUnit\Framework\TestCase
+class CRM_MagnetXmlImport_TransformerTest extends HeadlessTestCase
 {
-    /**
-     * The setup() method is executed before the test is executed (optional).
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    /**
-     * The tearDown() method is executed after the test was executed (optional)
-     * This can be used for cleanup.
-     */
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     /**
      * magnetTransactionToContact test case.
      */

--- a/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
+++ b/tests/phpunit/CRM/MagnetXmlImport/TransformerTest.php
@@ -3,7 +3,7 @@
 use Civi\MagnetXmlImport\HeadlessTestCase;
 
 /**
- * This is a generic test class for the extension (implemented with PHPUnit).
+ * @group headless
  */
 class CRM_MagnetXmlImport_TransformerTest extends HeadlessTestCase
 {

--- a/tests/phpunit/Civi/MagnetXmlImport/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/MagnetXmlImport/HeadlessTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Civi\MagnetXmlImport;
+
+use Civi\Test;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group headless
+ */
+class HeadlessTestCase extends TestCase implements HeadlessInterface
+{
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws \CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Resets DB
+        Test::headless()
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+
+    /**
+     * @return void
+     */
+    public function setUpHeadless(): void
+    {
+    }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,12 +1,14 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
+
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
-$loader = new \Composer\Autoload\ClassLoader();
+$loader = new ClassLoader();
 $loader->add('CRM_', __DIR__);
 $loader->add('Civi\\', __DIR__);
 $loader->add('api_', __DIR__);
@@ -29,9 +31,9 @@ $loader->register();
 function cv($cmd, $decode = 'json')
 {
     $cmd = 'cv '.$cmd;
-    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
+    $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
-    putenv("CV_OUTPUT=json");
+    putenv('CV_OUTPUT=json');
 
     // Execute `cv` in the original folder. This is a work-around for
     // phpunit/codeception, which seem to manipulate PWD.
@@ -51,8 +53,8 @@ function cv($cmd, $decode = 'json')
 
         case 'phpcode':
             // If the last output is /*PHPCODE*/, then we managed to complete execution.
-            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
-                throw new \RuntimeException("Command failed ($cmd):\n$result");
+            if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+                throw new RuntimeException("Command failed ($cmd):\n$result");
             }
 
             return $result;


### PR DESCRIPTION
- all test inherit single `HeadlessTestCase`
- remove `tearDown`
- rename `*HeadlessTest` to `*Test`
- move `HeadlessTestCase` to `\Civi` namespace
- standardize `setUpHeadless()` docblock
- test class docblock: keep only `@group headless`
- remove unused `HookInterface`, `TransactionalInterface`; if needed add only relevant test cases
